### PR TITLE
Remove dependency on Avahi

### DIFF
--- a/buildroot-external/package/snapcast/Config.in
+++ b/buildroot-external/package/snapcast/Config.in
@@ -1,13 +1,8 @@
 config BR2_PACKAGE_SNAPCAST
 	bool "Snapcast"
-	depends on BR2_USE_MMU # avahi
-	depends on !BR2_STATIC_LIBS # avahi
 	depends on BR2_TOOLCHAIN_HAS_THREADS
 	depends on BR2_INSTALL_LIBSTDCPP
 	select BR2_PACKAGE_AIXLOG
-	select BR2_PACKAGE_AVAHI
-	select BR2_PACKAGE_AVAHI_DAEMON
-	select BR2_PACKAGE_DBUS
 	select BR2_PACKAGE_POPL
 	select BR2_PACKAGE_ASIO
 	select BR2_PACKAGE_FLAC

--- a/buildroot-external/package/snapcast/snapcast.mk
+++ b/buildroot-external/package/snapcast/snapcast.mk
@@ -6,7 +6,7 @@
 
 SNAPCAST_VERSION = v0.13.0
 SNAPCAST_SITE = $(call github,badaix,snapcast,$(SNAPCAST_VERSION))
-SNAPCAST_DEPENDENCIES = libogg alsa-lib avahi # libstdcpp libatomic libflac libvorbisidec
+SNAPCAST_DEPENDENCIES = libogg alsa-lib # libstdcpp libatomic libflac libvorbisidec
 SNAPCAST_LICENSE = GPL-3.0+
 SNAPCAST_LICENSE_FILES = LICENSE
 

--- a/openwrt/snapcast/Makefile
+++ b/openwrt/snapcast/Makefile
@@ -25,7 +25,7 @@ define Package/snapcast/Default
 	SECTION := multimedia
 	CATEGORY := Multimedia
 	TITLE := snapcast
-	DEPENDS := +libstdcpp +libavahi-client +libatomic +libogg +libflac
+	DEPENDS := +libstdcpp +libatomic +libogg +libflac
 endef
 
 define Package/snapcast/description/Default


### PR DESCRIPTION
If Avahi is installed, Snapcast will benefit from it automatically. But depending on it draws in DBus as well and blows up the image.

(cf. badaix/snapcast#378)