### PR TITLE
v0.26.0

### DIFF
--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -40,7 +40,7 @@ In `make menuconfig` navigate to `Sound/snapcast` and select `Snapserver` and/or
 $ cd <wrt dir>
 $ make defconfig
 $ make menuconfig
-$ make
+$ make -j $(nproc)
 ```
 
 #### Rebuild Snapcast:

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -5,17 +5,24 @@ https://openwrt.org/docs/guide-developer/build-system/install-buildsystem
 ## OpenWrt build system setup
 https://openwrt.org/docs/guide-developer/build-system/install-buildsystem
 
-### Get OpenWrt
+### Get OpenWrt and SnapOS
 Clone OpenWrt to some place in your home directory (`<wrt dir>`)
 
     $ git clone https://git.openwrt.org/openwrt/openwrt.git
-    cd openwrt
-git pull
- 
+    $ git clone https://github.com/badaix/snapos.git
+        
 # Select a specific code revision
-    git branch -a
-    git tag
+    cd openwrt
+    git pull
     git checkout v21.02.2
+
+### Add snapcast
+Within the `<wrt dir>/package` directory create a symbolic link to `<snapos dir>/openwrt`: 
+
+```
+$ cd packages
+$ ln -s ../../snapos/openwrt ./snapcast
+```
 
 ### Download and install available feeds 
 
@@ -25,16 +32,8 @@ $ ./scripts/feeds update -a
 $ ./scripts/feeds install -a
 ```
 
-### Add snapcast
-Within the `<wrt dir>/package` directory create a symbolic link to `<snapos dir>/openwrt`: 
-
-```
-$ cd <wrt dir>
-$ ln -s <snapos dir>/openwrt package/snapcast
-```
-
 ### Build  
-In `make menuconfig` navigate to `Sound/snapcast` and select `Snapserver` and/or `Snapclient`
+In `make menuconfig` select your `Target System`, `Subtarget`, `Target Profile` and navigate to `Sound/snapcast` and select `Snapserver` and/or `Snapclient`
 
 ```
 $ cd <wrt dir>

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -9,6 +9,13 @@ https://openwrt.org/docs/guide-developer/build-system/install-buildsystem
 Clone OpenWrt to some place in your home directory (`<wrt dir>`)
 
     $ git clone https://git.openwrt.org/openwrt/openwrt.git
+    cd openwrt
+git pull
+ 
+# Select a specific code revision
+    git branch -a
+    git tag
+    git checkout v21.02.2
 
 ### Download and install available feeds 
 

--- a/openwrt/snapcast/Makefile
+++ b/openwrt/snapcast/Makefile
@@ -24,7 +24,7 @@ define Package/snapcast/Default
 	SECTION := sound
 	CATEGORY := Sound
 	TITLE := Synchronous multiroom audio player
-	DEPENDS := +libstdcpp +libavahi-client +libatomic +libogg +libflac +libopus +boost
+	DEPENDS := +libstdcpp +libavahi-client +libatomic +libogg +libflac +libopus +boost 
 	URL := https://github.com/badaix/snapcast
 endef
 
@@ -47,7 +47,7 @@ endef
 define Package/snapserver
 	$(call Package/snapcast/Default)
 	TITLE += Snapserver
-	DEPENDS += +libvorbis
+	DEPENDS += +AUDIO_SUPPORT:alsa-lib +libvorbis +libsoxr
 	HIDDEN := 1
 endef
 

--- a/openwrt/snapcast/Makefile
+++ b/openwrt/snapcast/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME := snapcast
-PKG_VERSION := 0.20.0
+PKG_VERSION := 0.26.0
 PKG_RELEASE := $(PKG_SOURCE_VERSION)
 PKG_USE_MIPS16 := 0
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/badaix/snapcast.git
-PKG_SOURCE_VERSION:=v0.20.0
+PKG_SOURCE_VERSION:=v0.26.0
 PKG_BUILD_DIR:=$(BUILD_DIR)/snapcast-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
- Bumped Makefile to build v0.26.0
- Added missing dependencies that were causing build to fail
- Changed some build instructions to try to clarify some points that made building difficult to follow.
- Added binaries for RPi4B (64bit) to releases (aarch64_cortex-a72)
    Feel free to request additional targets and I would be happy to try to build them for release