### PR TITLE
Fixed snapcast etc/default files copy into package - supersedes PR #28/#26

### DIFF
--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -110,7 +110,7 @@ Also make sure to select your device in the target settings.
 $ cd <wrt dir>
 $ make defconfig
 $ make menuconfig
-$ make
+$ make package/snapcast/compile
 ```
 
 The packaged `ipk` file is in  

--- a/openwrt/snapcast/Makefile
+++ b/openwrt/snapcast/Makefile
@@ -99,7 +99,7 @@ define Package/snapserver/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/snapserver.init $(1)/etc/init.d/snapserver
 	$(INSTALL_DIR) $(1)/etc/default
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/debian/snapserver.default $(1)/etc/default/snapserver
+	$(INSTALL_BIN) $(CURDIR)/../../debian/snapserver.default $(1)/etc/default/snapserver
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/server/etc/snapserver.conf $(1)/etc/snapserver.conf
 endef
 
@@ -109,7 +109,7 @@ define Package/snapclient/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/snapclient.init $(1)/etc/init.d/snapclient
 	$(INSTALL_DIR) $(1)/etc/default
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/debian/snapclient.default $(1)/etc/default/snapclient
+	$(INSTALL_BIN) $(CURDIR)/../../debian/snapclient.default $(1)/etc/default/snapclient
 endef
 
 $(eval $(call BuildPackage,snapserver))


### PR DESCRIPTION
@badaix This PR aims to do [all the work for you regarding restoring successful package compilation support on OpenWRT 23.05+](https://github.com/badaix/snapos/issues/27#issuecomment-1982323030) - you contribution is reviewing/merging this please :-)

This PR:
- offers a long term solution relying on OpenWRT provided variable to find the relevant debian directory to copy the config files from. 
- document how to compile only the snapcast package + dependencies - #Credit to #28

**This PR supersedes #26** 

The instructions in #26 to successfully install the default snapserver/snapclient default config relied on a symlink trick.
On OpenWRT 23.05, the symlink did not resolve to the intended directory. As a result, the package building failed.

**This PR supersedes #28**

The instructions in #28 allowed one to produce a package without same config files. 

**This PR solves #23**
No comment.

